### PR TITLE
Use explicit NULL_FEED for empty pricefeeds

### DIFF
--- a/src/AbstractYodlRouter.sol
+++ b/src/AbstractYodlRouter.sol
@@ -15,6 +15,8 @@ abstract contract AbstractYodlRouter {
     address public constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     uint256 public constant MAX_EXTRA_FEE_BPS = 5_000; // 50%
     address public constant RATE_VERIFIER = 0xc71f6e1e4665d319610afA526BE529202cA13bB7;
+
+    int8 public constant NULL_FEED = 0;
     int8 public constant CHAINLINK_FEED = 1;
     int8 public constant EXTERNAL_FEED = 2;
 
@@ -139,7 +141,7 @@ abstract contract AbstractYodlRouter {
         int256 price;
 
         if (priceFeeds[0].feedType == EXTERNAL_FEED) {
-            decimals = 18;
+            decimals = uint256(10 ** uint256(18));
             price = int256(priceFeeds[0].amount);
             prices[0] = price;
         } else {

--- a/src/routers/YodlCurveRouter.sol
+++ b/src/routers/YodlCurveRouter.sol
@@ -46,7 +46,10 @@ abstract contract YodlCurveRouter is AbstractYodlRouter {
 
         // This is how much the recipient needs to receive
         uint256 amountOutExpected;
-        if (params.priceFeeds[0].feedAddress != address(0) || params.priceFeeds[1].feedAddress != address(0)) {
+        if (
+            params.priceFeeds[0].feedType != NULL_FEED ||
+            params.priceFeeds[1].feedType != NULL_FEED
+        ) {
             // Convert amountOut from invoice currency to swap currency using price feed
             int256[2] memory prices;
             address[2] memory priceFeeds;

--- a/src/routers/YodlTransferRouter.sol
+++ b/src/routers/YodlTransferRouter.sol
@@ -79,7 +79,10 @@ abstract contract YodlTransferRouter is AbstractYodlRouter {
         uint256 finalAmount = params.amount;
 
         // transform amount with priceFeeds
-        if (params.priceFeeds[0].feedAddress != address(0) || params.priceFeeds[1].feedAddress != address(0)) {
+        if (
+            params.priceFeeds[0].feedType != NULL_FEED ||
+            params.priceFeeds[1].feedType != NULL_FEED
+        ) {
             {
                 int256[2] memory prices;
                 address[2] memory priceFeedsUsed;

--- a/src/routers/YodlUniswapRouter.sol
+++ b/src/routers/YodlUniswapRouter.sol
@@ -48,7 +48,10 @@ abstract contract YodlUniswapRouter is AbstractYodlRouter {
 
         // This is how much the recipient needs to receive
         uint256 amountOutExpected;
-        if (params.priceFeeds[0].feedAddress != address(0) || params.priceFeeds[1].feedAddress != address(0)) {
+        if (
+            params.priceFeeds[0].feedType != NULL_FEED ||
+            params.priceFeeds[1].feedType != NULL_FEED
+        ) {
             // Convert amountOut from invoice currency to swap currency using price feed
             int256[2] memory prices;
             address[2] memory priceFeeds;


### PR DESCRIPTION
- Add `NULL_FEED` when not using a feed
- Fix rate calculation for external feed