### PR TITLE
Andyoeee/yodl 520 fix across param

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,3 +9,5 @@ BLOCK_NUMBER=20656242
 # OLD,not sure of its use
 PRIVATE_KEY="0x..."
 SENDER="0x..."
+
+DEFAULT_ANVIL_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,11 @@ coverage-debug :; forge coverage --fork-url ${RPC_URL} --fork-block-number ${BLO
 
 test-all: test test-fork
 
-start-anvil :; nohup anvil --fork-url=${RPC_URL} --fork-block-number ${BLOCK_NUMBER} &
+# start-anvil :; nohup anvil --fork-url=${RPC_URL} --fork-block-number ${BLOCK_NUMBER} &
+start-anvil :; anvil --fork-url=${RPC_URL} --fork-block-number ${BLOCK_NUMBER}
+
+deploy-anvil :; forge create --rpc-url http://localhost:8545 ${CONTRACT} --private-key ${DEFAULT_ANVIL_KEY} | tee deployment.txt
+# e,g.: make deploy-anvil CONTRACT=src/chains/BaseYodlRouter.sol:YodlRouter
 
 stop-testnet :; pkill anvil
 

--- a/src/routers/YodlAcrossRouter.sol
+++ b/src/routers/YodlAcrossRouter.sol
@@ -93,6 +93,13 @@ abstract contract YodlAcrossRouter is AbstractYodlRouter {
         // Transfer to receiver
         TransferHelper.safeApprove(params.token, address(acrossSpokePool), outAmountGross);
 
+        // exclusivityDeadline is provided as the number of seconds for a single relayer to fill the deposit, e.g. 10.
+        // It should be passed toi depositV3 as a unix timestamp in seconds.
+        uint32 exclusivityDeadline = params.exclusivityDeadline;
+        if (exclusivityDeadline != 0) {
+            exclusivityDeadline += uint32(block.timestamp);
+        }
+
         acrossSpokePool.depositV3(
             msg.sender, // address depositor,
             params.receiver, // address recipient,
@@ -104,7 +111,7 @@ abstract contract YodlAcrossRouter is AbstractYodlRouter {
             params.exclusiveRelayer, // address exclusiveRelayer,
             params.quoteTimestamp, // uint32 quoteTimestamp,
             params.fillDeadline, // uint32 fillDeadline,
-            params.exclusivityDeadline, // uint32 exclusivityDeadline,
+            exclusivityDeadline, // uint32 exclusivityDeadline,
             params.message // bytes calldata message
         );
     }

--- a/src/routers/YodlAcrossRouter.sol
+++ b/src/routers/YodlAcrossRouter.sol
@@ -97,6 +97,8 @@ abstract contract YodlAcrossRouter is AbstractYodlRouter {
         // It should be passed toi depositV3 as a unix timestamp in seconds.
         uint32 exclusivityDeadline = params.exclusivityDeadline;
         if (exclusivityDeadline != 0) {
+            // Prevent overflow when adding to block.timestamp
+            require(exclusivityDeadline <= type(uint32).max - block.timestamp, "exclusivity deadline overflow");
             exclusivityDeadline += uint32(block.timestamp);
         }
 

--- a/src/routers/YodlAcrossRouter.sol
+++ b/src/routers/YodlAcrossRouter.sol
@@ -43,26 +43,18 @@ abstract contract YodlAcrossRouter is AbstractYodlRouter {
         acrossSpokePool = V3SpokePoolInterface(_acrossSpokePool);
     }
 
-    function yodlWithAcross(
-        YodlAcrossParams calldata params
-    ) external payable returns (uint256) {
+    function yodlWithAcross(YodlAcrossParams calldata params) external payable returns (uint256) {
         require(params.amount != 0, "invalid amount");
         require(params.token != NATIVE_TOKEN, "only ERC20 supported");
 
         uint256 outAmountGross = params.amount;
 
         // transform amount with priceFeeds
-        if (
-            params.priceFeeds[0].feedType != NULL_FEED ||
-            params.priceFeeds[1].feedType != NULL_FEED
-        ) {
+        if (params.priceFeeds[0].feedType != NULL_FEED || params.priceFeeds[1].feedType != NULL_FEED) {
             {
                 int256[2] memory prices;
                 address[2] memory priceFeedsUsed;
-                (outAmountGross, priceFeedsUsed, prices) = exchangeRate(
-                    params.priceFeeds,
-                    params.amount
-                );
+                (outAmountGross, priceFeedsUsed, prices) = exchangeRate(params.priceFeeds, params.amount);
                 emitConversionEvent(params.priceFeeds, prices);
             }
         }
@@ -70,9 +62,7 @@ abstract contract YodlAcrossRouter is AbstractYodlRouter {
         if (params.token != NATIVE_TOKEN) {
             // ERC20 token
             require(
-                IERC20(params.token).allowance(msg.sender, address(this)) >=
-                    outAmountGross,
-                "insufficient allowance"
+                IERC20(params.token).allowance(msg.sender, address(this)) >= outAmountGross, "insufficient allowance"
             );
         }
 
@@ -92,39 +82,20 @@ abstract contract YodlAcrossRouter is AbstractYodlRouter {
             }
         }
 
-        TransferHelper.safeTransferFrom(
-            params.token,
-            msg.sender,
-            address(this),
-            params.amount
-        );
+        TransferHelper.safeTransferFrom(params.token, msg.sender, address(this), params.amount);
         depositToAcross(outAmountGross, params);
 
-        emit Yodl(
-            msg.sender,
-            params.receiver,
-            params.token,
-            outAmountGross,
-            totalFee,
-            params.memo
-        );
+        emit Yodl(msg.sender, params.receiver, params.token, outAmountGross, totalFee, params.memo);
 
         return outAmountNet;
     }
 
-    function depositToAcross(
-        uint256 outAmountGross,
-        YodlAcrossParams calldata params
-    ) internal {
+    function depositToAcross(uint256 outAmountGross, YodlAcrossParams calldata params) internal {
         // Transfer to receiver
-        TransferHelper.safeApprove(
-            params.token,
-            address(acrossSpokePool),
-            params.amount
-        );
+        TransferHelper.safeApprove(params.token, address(acrossSpokePool), params.amount);
 
-        // exclusivityDeadline is provided as the number of seconds for a single relayer to fill the deposit, e.g. 10.
-        // It should be passed toi depositV3 as a unix timestamp in seconds.
+        // Across api provides exclusivityDeadline as number of seconds for a single relayer to fill the deposit, e.g. 10.
+        // The SC, expects it to be a unix timestamp in seconds.
         uint32 exclusivityDeadline = params.exclusivityDeadline;
         if (exclusivityDeadline != 0) {
             // Prevent overflow when adding to block.timestamp


### PR DESCRIPTION
This is a fix for the CB wallet revert error.

It is caused by passing  `exclusivityDeadline` to `acrossSpokePool.depositV3` without modifying it.