### PR TITLE
remove unwrapping native token on Curve router

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,4 @@
 @chainlink/contracts/=lib/foundry-chainlink-toolkit/lib/chainlink-brownie-contracts/contracts/src/
-@openzeppelin/=lib/foundry-chainlink-toolkit/lib/openzeppelin-contracts/
 @openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
 chainlink-brownie-contracts/=lib/foundry-chainlink-toolkit/lib/chainlink-brownie-contracts/contracts/src/v0.6/vendor/@arbitrum/nitro-contracts/src/
 chainlink/=lib/chainlink/contracts/

--- a/src/routers/YodlCurveRouter.sol
+++ b/src/routers/YodlCurveRouter.sol
@@ -112,7 +112,7 @@ abstract contract YodlCurveRouter is AbstractYodlRouter {
             // Contrary to Uniswap on Curve we receive native token directly - no need to unwrap.
             uint256 nativeBalance = address(this).balance;
             require(nativeBalance >= outAmountGross, "Native balance is less than outAmountGross");
-
+            // transfer native tokens to receiver
             (bool success,) = params.receiver.call{value: outAmountGross - totalFee}("");
             require(success, "transfer of native to receiver failed");
             emit YodlNativeTokenTransfer(params.sender, params.receiver, outAmountGross - totalFee);

--- a/src/routers/YodlCurveRouter.sol
+++ b/src/routers/YodlCurveRouter.sol
@@ -109,12 +109,10 @@ abstract contract YodlCurveRouter is AbstractYodlRouter {
                 transferFee(outAmountGross, params.extraFeeBps, tokenOut, address(this), params.extraFeeReceiver);
         }
         if (tokenOut == NATIVE_TOKEN) {
-            // Handle unwrapping wrapped native token
-            uint256 balance = IWETH9(wrappedNativeToken).balanceOf(address(this));
-            // Unwrap and use NATIVE_TOKEN address as tokenOut
-            require(balance >= outAmountGross, "Wrapped balance is less then outAmountGross");
-            IWETH9(wrappedNativeToken).withdraw(balance);
-            // Need to transfer native token to receiver
+            // Contrary to Uniswap on Curve we receive native token directly - no need to unwrap.
+            uint256 nativeBalance = address(this).balance;
+            require(nativeBalance >= outAmountGross, "Native balance is less than outAmountGross");
+
             (bool success,) = params.receiver.call{value: outAmountGross - totalFee}("");
             require(success, "transfer of native to receiver failed");
             emit YodlNativeTokenTransfer(params.sender, params.receiver, outAmountGross - totalFee);

--- a/src/routers/YodlCurveRouter.sol
+++ b/src/routers/YodlCurveRouter.sol
@@ -67,31 +67,41 @@ abstract contract YodlCurveRouter is AbstractYodlRouter {
             }
         }
 
-        // There should be no other situation in which we send a transaction with native token
-        if (msg.value != 0) {
-            // Wrap the native token
-            require(msg.value >= params.amountIn, "insufficient gas provided");
-            wrappedNativeToken.deposit{value: params.amountIn}();
+        bool isNativeTokenIn = tokenIn == NATIVE_TOKEN;
 
-            // Update the tokenIn to wrapped native token
-            // wrapped native token has the same number of decimals as native token
-            // wrapped native token is already the first token in the route parameter
-            tokenIn = address(wrappedNativeToken);
+        // Handle native token input
+        if (isNativeTokenIn) {
+            require(msg.value >= params.amountIn, "insufficient gas provided");
+            // We don't wrap the native token here anymore
         } else {
             // Transfer the ERC20 token from the sender to the YodlRouter
             TransferHelper.safeTransferFrom(tokenIn, msg.sender, address(this), params.amountIn);
+            TransferHelper.safeApprove(tokenIn, address(curveRouter), params.amountIn);
         }
-        TransferHelper.safeApprove(tokenIn, address(curveRouter), params.amountIn);
 
         // Make the swap - the YodlRouter will receive the tokens
-        uint256 amountOut = curveRouter.exchange(
-            params.route,
-            params.swapParams,
-            params.amountIn,
-            outAmountGross, // this will revert if we do not get at least this amount
-            params.pools, // this is for zap contracts
-            address(this) // the Yodl router will receive the tokens
-        );
+        uint256 amountOut;
+        if (isNativeTokenIn) {
+            // Call the Curve router with native ETH
+            amountOut = curveRouter.exchange{value: params.amountIn}(
+                params.route,
+                params.swapParams,
+                params.amountIn,
+                outAmountGross, // this will revert if we do not get at least this amount
+                params.pools, // this is for zap contracts
+                address(this) // the Yodl router will receive the tokens
+            );
+        } else {
+            // Call the Curve router with ERC20 tokens
+            amountOut = curveRouter.exchange(
+                params.route,
+                params.swapParams,
+                params.amountIn,
+                outAmountGross, // this will revert if we do not get at least this amount
+                params.pools, // this is for zap contracts
+                address(this) // the Yodl router will receive the tokens
+            );
+        }
         require(amountOut >= outAmountGross, "amountOut is less then outAmountGross");
 
         // Handle fees for the transaction - in terms out the token out

--- a/src/routers/YodlCurveRouter.sol
+++ b/src/routers/YodlCurveRouter.sol
@@ -6,8 +6,9 @@ pragma solidity ^0.8.26;
 import "../interfaces/ICurveRouterNG.sol";
 import "../AbstractYodlRouter.sol";
 import "../interfaces/IBeforeHook.sol";
+import "@openzeppelin/contracts//utils/ReentrancyGuard.sol";
 
-abstract contract YodlCurveRouter is AbstractYodlRouter {
+abstract contract YodlCurveRouter is AbstractYodlRouter, ReentrancyGuard {
     ICurveRouterNG public curveRouter;
 
     /// @notice Parameters for a payment through Curve
@@ -42,7 +43,7 @@ abstract contract YodlCurveRouter is AbstractYodlRouter {
     /// of slippage are in terms of the token out.
     /// @param params Struct that contains all the relevant parameters. See `YodlCurveParams` for more details.
     /// @return The amount received in terms of token out by the Curve swap
-    function yodlWithCurve(YodlCurveParams calldata params) external payable returns (uint256) {
+    function yodlWithCurve(YodlCurveParams calldata params) external payable nonReentrant returns (uint256) {
         require(address(curveRouter) != address(0), "curve router not present");
         (address tokenOut, address tokenIn) = decodeTokenOutTokenInCurve(params.route);
 

--- a/src/routers/YodlUniswapRouter.sol
+++ b/src/routers/YodlUniswapRouter.sol
@@ -139,6 +139,7 @@ abstract contract YodlUniswapRouter is AbstractYodlRouter {
         }
 
         if (tokenOut == NATIVE_TOKEN) {
+            // transfer native tokens to receiver
             (bool success,) = params.receiver.call{value: outAmountGross - totalFee}("");
             require(success, "transfer failed");
             emit YodlNativeTokenTransfer(params.sender, params.receiver, outAmountGross - totalFee);


### PR DESCRIPTION
Contrary to Uniswap, Curve router can quote and swap native tokens directly.
Therefore we should not unwrap when swapping to native.

Tested on base (ETH) and gnosis (xDAI).

REMINDER: When this is merged we should turn on native tokens for Curve in Dapp:
`frontend/shared/routefinder/quotes.tsx: fetchOperations`

EDIT:
- Also removed wrapping when tokenIn is native. 
- Added nonReentrant modifier.